### PR TITLE
added support for providing an external IPFS API endpoint as argument

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -12,4 +12,8 @@ argv
   .demand(1)
   .help('help')
   .alias('h', 'help')
+  .option('ipfs-api-endpoint', {
+    alias: 'ipfs',
+    describe: 'IPFS API endpoint to use instead of bringing up one.'
+  })
   .argv

--- a/src/commands/id.js
+++ b/src/commands/id.js
@@ -21,7 +21,7 @@ exports.handler = async (argv) => {
     ipfsConfig.start = true
   }
 
-  const ipfs = await startIpfs(ipfsConfig)
+  const ipfs = await startIpfs(ipfsConfig, argv)
   const peerId = await ipfs.config.get('Identity.PeerID')
   process.stdout.write(`${peerId}\n`)
 

--- a/src/commands/key.js
+++ b/src/commands/key.js
@@ -19,7 +19,7 @@ exports.builder = (yargs) => {
 
 exports.handler = async (argv) => {
   const ipfsConfig = Object.assign({}, config.ipfsConfig)
-  const ipfs = await startIpfs(ipfsConfig)
+  const ipfs = await startIpfs(ipfsConfig, argv)
   const directory = process.env.ORBITDB_PATH || config.defaultDatabaseDir
   const orbitdb = new OrbitDB(ipfs, directory)
   process.stdout.write(`${orbitdb.key.getPublic('hex')}\n`)

--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,7 @@ const conf = {
   repo: process.env.IPFS_PATH || path.join(defaultOrbitDbDir, '/ipfs'),
   start: false,
   EXPERIMENTAL: {
-    pubsub: true,
+    pubsub: true
   },
   config: {
     Addresses: {

--- a/src/lib/create-database.js
+++ b/src/lib/create-database.js
@@ -7,7 +7,7 @@ const OrbitDB = require('orbit-db')
 
 const createDatabase = async (database, type, argv) => {
   // TODO: add database path config: { repo: path.join('./.orbitdb') }
-  const ipfs = await startIpfs(config.ipfsConfig)
+  const ipfs = await startIpfs(config.ipfsConfig, argv)
   const peerId = await ipfs.config.get('Identity.PeerID')
   // We need to pass the IPFS ID since we're not starting IPFS
   const directory = process.env.ORBITDB_PATH || config.defaultDatabaseDir

--- a/src/lib/open-database.js
+++ b/src/lib/open-database.js
@@ -19,7 +19,7 @@ const openDatabase = async (database, argv, openAsType) => {
   logger.debug(`Going online: ${ipfsConfig.start}`)
   if (ipfsConfig.start) logger.info(`IPFS going online!`)
 
-  const ipfs = await startIpfs(ipfsConfig)
+  const ipfs = await startIpfs(ipfsConfig, argv)
 
   const peerId = await ipfs.config.get('Identity.PeerID')
   logger.debug("PeerID:", peerId)

--- a/src/start-ipfs.js
+++ b/src/start-ipfs.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const IPFS = require('ipfs')
+const IpfsApi = require('ipfs-api')
 const IPFSRepo = require('ipfs-repo')
 const DatastoreLevel = require('datastore-level')
 
@@ -10,12 +11,26 @@ const repoConf = {
   },
 }
 
-const startIpfs = (config = {}) => {
+const startIpfs = (config = {}, argv) => {
   return new Promise((resolve, reject) => {
     config = Object.assign({}, config, { repo: new IPFSRepo(config.repo, repoConf) })
-    const ipfs = new IPFS(config)
-    ipfs.on('error', reject)
-    ipfs.on('ready', () => resolve(ipfs))
+    if (argv.ipfsApiEndpoint) {
+      if (typeof argv.ipfsApiEndpoint == 'string')
+        var [ipfsHost, ipfsPort] = argv.ipfsApiEndpoint.split(':')
+      else
+        /* FIXME:
+         we shud get the default from yargs when only "--ipfs-api-endpoint"
+         was provided, but since yargs is returning "true" as provided value,
+         I haven't found a way to reach the real default. */
+        var [ipfsHost, ipfsPort] = ["localhost", "5001"]
+      const ipfs = IpfsApi(ipfsHost, ipfsPort)
+      resolve(ipfs)
+    }
+    else {
+      const ipfs = new IPFS(config)
+      ipfs.on('error', reject)
+      ipfs.on('ready', () => resolve(ipfs))
+    }
   })
 }
 


### PR DESCRIPTION
I haven't seen any other options to do this, so since I needed to use my own endpoint, I implemented this approach.

There are no tests so far, but if you think it's a good idea to merge, we can discuss how it should be tested!